### PR TITLE
Fix infinite rebuild recursion in settings UI

### DIFF
--- a/main/src/net/liplum/ui/settings/SettingsTableX.kt
+++ b/main/src/net/liplum/ui/settings/SettingsTableX.kt
@@ -1,40 +1,55 @@
 package net.liplum.ui.settings
 
 import arc.Core
-import mindustry.ui.dialogs.SettingsMenuDialog.SettingsTable
+import arc.scene.ui.layout.Cell
+import mindustry.ui.dialogs.SettingsMenuDialog
 import net.liplum.common.delegate.Delegate
 import plumy.dsl.bundle
+import kotlin.jvm.functions.Function0
+import kotlin.jvm.functions.Function1
 
-class SettingsTableX : SettingsTable() {
+class SettingsTableX : SettingsMenuDialog.SettingsTable() {
     val onReset = Delegate()
-    fun onSettingsReset(handler: () -> Unit) {
+    var genHeader: (SettingsTableX) -> Unit = {}
+    private var rebuilding = false
+    fun onSettingsReset(handler: Function0<Unit>) {
         onReset.add(handler)
     }
 
-    var genHeader: (SettingsTableX) -> Unit = {}
-        set(value) {
-            field = value
-            rebuild()
-        }
-
     override fun rebuild() {
-        clearChildren()
+        if (rebuilding) return
+        rebuilding = true
 
-        genHeader(this)
-        for (setting in list) {
-            if (setting is ISettingCondition && !setting.canShow()) continue
-            setting.add(this)
-        }
-        button("settings.reset".bundle) {
+        try {
+            clearChildren()
+            genHeader(this)
             for (setting in list) {
-                if (setting.name == null || setting.title == null) continue
-                Core.settings.put(setting.name, Core.settings.getDefault(setting.name))
+                if (setting is ISettingCondition && !setting.canShow()) continue
+                setting.add(this)
             }
-            onReset()
-            rebuild()
-        }.margin(14f).width(240f).pad(6f)
-        for (cell in cells) {
-            cell.pad(5f)
+            button(
+                bundle("settings.reset", "Reset to Defaults")
+            ) {
+                resetSettings()
+            }.margin(14f).width(240f).pad(6f)
+            for (cell: Cell<*> in cells) {
+                cell.pad(5f)
+            }
+        } finally {
+            rebuilding = false
         }
+    }
+
+    private fun resetSettings() {
+        for (setting in list) {
+            if (setting.name != null && setting.title != null) {
+                Core.settings.put(
+                    setting.name,
+                    Core.settings.getDefault(setting.name)
+                )
+            }
+        }
+        onReset.invoke()
+        rebuild()
     }
 }


### PR DESCRIPTION
Probably fixes settings menu crash

SettingsTableX was recursively calling rebuild() and
crashing the settings menu.
Added a guard to stop infinite recursion.

Seems to work, but I might be missing something.
